### PR TITLE
Removed deprecated version attr from docker-compose.override

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,5 +1,4 @@
 # Use this file to map ports and other configurations to your services for local development.
-version: '3'
 services:
     marketplace.skeleton:
         ports:


### PR DESCRIPTION
I also changed the name of the file since it was the override was not in the right location in the file (something I noticed before while using it)