### PR TITLE
🐘  Use postgres for tests

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'default' => env('DB_CONNECTION', 'mysql'),
+    'default' => env('DB_CONNECTION', 'pgsql'),
 
     /*
     |--------------------------------------------------------------------------

--- a/database/docker-entrypoint-initdb.d/create-extension-uuid-ossp.sql
+++ b/database/docker-entrypoint-initdb.d/create-extension-uuid-ossp.sql
@@ -1,0 +1,4 @@
+\c marketplace_skeleton;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" CASCADE;
+\c testing;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" CASCADE;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
             POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
         volumes:
             - 'sailpgsql:/var/lib/postgresql/data'
+            - './vendor/laravel/sail/database/pgsql/create-testing-database.sql:/docker-entrypoint-initdb.d/10-create-testing-database.sql'
+            - './database/docker-entrypoint-initdb.d/create-extension-uuid-ossp.sql:/docker-entrypoint-initdb.d/11-create-extension-uuid-ossp.sql'
         networks:
             - sail
         healthcheck:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,10 +7,10 @@
 >
     <testsuites>
         <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
+            <directory>./tests/Unit</directory>
         </testsuite>
         <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
+            <directory>./tests/Feature</directory>
         </testsuite>
     </testsuites>
     <php>
@@ -19,8 +19,7 @@
         <server name="LOG_CHANNEL" value="null"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
-        <server name="DB_CONNECTION" value="sqlite"/>
-        <server name="DB_DATABASE" value=":memory:"/>
+        <server name="DB_DATABASE" value="testing"/>
         <server name="MAIL_MAILER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>
@@ -28,7 +27,7 @@
     </php>
     <source>
         <include>
-            <directory suffix=".php">./app</directory>
+            <directory>./app</directory>
         </include>
     </source>
 </phpunit>


### PR DESCRIPTION
# What's Changed
@yoerriwalstra and me noticed that marketplace-skeleton still used sqlite for testing by default. We can just rely on pgsql since sqlite has too many differences with postgres.