### PR TITLE
Fixed 2 small bugs in the ShopController

### DIFF
--- a/app/Shops/Http/Controllers/ShopController.php
+++ b/app/Shops/Http/Controllers/ShopController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Shops\Http\Controllers;
 
-use Illuminate\Http\Response;
 use MyParcelCom\Integration\Configuration\Form\Checkbox;
 use MyParcelCom\Integration\Configuration\Form\Form;
 use MyParcelCom\Integration\Configuration\Form\Number;
@@ -19,6 +18,7 @@ use MyParcelCom\Integration\Configuration\Values\ValueCollection;
 use MyParcelCom\Integration\Shop\Http\Requests\ShopSetupRequest;
 use MyParcelCom\Integration\Shop\Http\Responses\ShopSetupResponse;
 use MyParcelCom\Integration\Shop\Http\Responses\ShopTearDownResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 class ShopController
 {
@@ -82,10 +82,9 @@ class ShopController
         return new ConfigurationResponse($form, $values);
     }
 
-    public function configure(ConfigureRequest $request): Response
+    public function configure(ConfigureRequest $request, string $shopId): Response
     {
         // TODO: Save the shop's configuration settings
-        $shopId = $request->shopId();
 
         return new Response('', Response::HTTP_NO_CONTENT);
     }


### PR DESCRIPTION
As I was working on the WMS skeleton I noticed 3 issues with this project:
- `ShopController` - Uses `Illiminate` and `Symphony` responses interchangebly instead of picking one in the configure request
- `ShopController` - `configure` uses `$request->shopId()`. This is incorrect since the shop's id is passed as a URL param
- **Found but not fixed:** The skeleton is locked to an older version of the marketplace commons so it does not utilize the new `json-schema-form-builder` package. This however was not straightfarward to fix since there are some dependency comflicts between vendor packages so it was left unfixed
